### PR TITLE
Dupemetrics fix

### DIFF
--- a/collector/asserts.go
+++ b/collector/asserts.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	assertsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	assertsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "asserts_total",
 		Help:      "The asserts document reports the number of asserts on the database. While assert errors are typically uncommon, if there are non-zero values for the asserts, you should check the log file for the mongod process for more information. In many cases these errors are trivial, but are worth investigating.",

--- a/collector/background_flushing.go
+++ b/collector/background_flushing.go
@@ -7,13 +7,13 @@ import (
 )
 
 var (
-	backgroundFlushingflushesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	backgroundFlushingflushesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "flushes_total",
 		Help:      "flushes is a counter that collects the number of times the database has flushed all writes to disk. This value will grow as database runs for longer periods of time",
 	})
-	backgroundFlushingtotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	backgroundFlushingtotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "background_flushing",
 		Name:      "total_milliseconds",

--- a/collector/collection_status.go
+++ b/collector/collection_status.go
@@ -1,10 +1,10 @@
 package collector
 
 import (
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/collector/conn_pool_stats.go
+++ b/collector/conn_pool_stats.go
@@ -1,10 +1,10 @@
 package collector
 
 import (
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // server connections -- all of these!
@@ -37,7 +37,7 @@ var (
 		Help:      "Corresponds to the total number of client connections to mongo that are currently available.",
 	})
 
-	totalCreated = prometheus.NewCounter(prometheus.CounterOpts{
+	totalCreated = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "connpoolstats",
 		Name:      "connections_created_total",

--- a/collector/connections.go
+++ b/collector/connections.go
@@ -12,7 +12,7 @@ var (
 	}, []string{"state"})
 )
 var (
-	connectionsMetricsCreatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	connectionsMetricsCreatedTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "connections_metrics",
 		Name:      "created_total",

--- a/collector/database_status.go
+++ b/collector/database_status.go
@@ -3,10 +3,10 @@ package collector
 import (
 	"strings"
 
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/collector/global_lock.go
+++ b/collector/global_lock.go
@@ -11,7 +11,7 @@ var (
 		Name:      "ratio",
 		Help:      "The value of ratio displays the relationship between lockTime and totalTime. Low values indicate that operations have held the globalLock frequently for shorter periods of time. High values indicate that operations have held globalLock infrequently for longer periods of time",
 	})
-	globalLockTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	globalLockTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "global_lock",
 		Name:      "total",

--- a/collector/index_counters.go
+++ b/collector/index_counters.go
@@ -14,7 +14,7 @@ var (
 )
 
 var (
-	indexCountersTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	indexCountersTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "index_counters_total",
 		Help:      "Total indexes by type",

--- a/collector/locks.go
+++ b/collector/locks.go
@@ -5,21 +5,21 @@ import (
 )
 
 var (
-	locksTimeLockedGlobalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	locksTimeLockedGlobalMicrosecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "locks_time_locked_global_microseconds_total",
 		Help:      "amount of time in microseconds that any database has held the global lock",
 	}, []string{"type", "database"})
 )
 var (
-	locksTimeLockedLocalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	locksTimeLockedLocalMicrosecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "locks_time_locked_local_microseconds_total",
 		Help:      "amount of time in microseconds that any database has held the local lock",
 	}, []string{"type", "database"})
 )
 var (
-	locksTimeAcquiringGlobalMicrosecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	locksTimeAcquiringGlobalMicrosecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "locks_time_acquiring_global_microseconds_total",
 		Help:      "amount of time in microseconds that any database has spent waiting for the global lock",

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	metricsCursorTimedOutTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsCursorTimedOutTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_cursor",
 		Name:      "timed_out_total",
@@ -20,7 +20,7 @@ var (
 	}, []string{"state"})
 )
 var (
-	metricsDocumentTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsDocumentTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_document_total",
 		Help:      "The document holds a document of that reflect document access and modification patterns and data use. Compare these values to the data in the opcounters document, which track total number of operations",
@@ -33,7 +33,7 @@ var (
 		Name:      "num_total",
 		Help:      "num reports the total number of getLastError operations with a specified write concern (i.e. w) that wait for one or more members of a replica set to acknowledge the write operation (i.e. a w value greater than 1.)",
 	})
-	metricsGetLastErrorWtimeTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsGetLastErrorWtimeTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error_wtime",
 		Name:      "total_milliseconds",
@@ -41,7 +41,7 @@ var (
 	})
 )
 var (
-	metricsGetLastErrorWtimeoutsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsGetLastErrorWtimeoutsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_get_last_error",
 		Name:      "wtimeouts_total",
@@ -49,21 +49,21 @@ var (
 	})
 )
 var (
-	metricsOperationTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsOperationTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_operation_total",
 		Help:      "operation is a sub-document that holds counters for several types of update and query operations that MongoDB handles using special operation types",
 	}, []string{"type"})
 )
 var (
-	metricsQueryExecutorTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsQueryExecutorTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_query_executor_total",
 		Help:      "queryExecutor is a document that reports data from the query execution system",
 	}, []string{"state"})
 )
 var (
-	metricsRecordMovesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsRecordMovesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_record",
 		Name:      "moves_total",
@@ -71,13 +71,13 @@ var (
 	})
 )
 var (
-	metricsReplApplyBatchesNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplApplyBatchesNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_apply_batches",
 		Name:      "num_total",
 		Help:      "num reports the total number of batches applied across all databases",
 	})
-	metricsReplApplyBatchesTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplApplyBatchesTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_apply_batches",
 		Name:      "total_milliseconds",
@@ -85,7 +85,7 @@ var (
 	})
 )
 var (
-	metricsReplApplyOpsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplApplyOpsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_apply",
 		Name:      "ops_total",
@@ -99,7 +99,7 @@ var (
 		Name:      "count",
 		Help:      "count reports the current number of operations in the oplog buffer",
 	})
-	metricsReplBufferMaxSizeBytes = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplBufferMaxSizeBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_buffer",
 		Name:      "max_size_bytes",
@@ -113,13 +113,13 @@ var (
 	})
 )
 var (
-	metricsReplNetworkGetmoresNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkGetmoresNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network_getmores",
 		Name:      "num_total",
 		Help:      "num reports the total number of getmore operations, which are operations that request an additional set of operations from the replication sync source.",
 	})
-	metricsReplNetworkGetmoresTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkGetmoresTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network_getmores",
 		Name:      "total_milliseconds",
@@ -127,19 +127,19 @@ var (
 	})
 )
 var (
-	metricsReplNetworkBytesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkBytesTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network",
 		Name:      "bytes_total",
 		Help:      "bytes reports the total amount of data read from the replication sync source",
 	})
-	metricsReplNetworkOpsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkOpsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network",
 		Name:      "ops_total",
 		Help:      "ops reports the total number of operations read from the replication source.",
 	})
-	metricsReplNetworkReadersCreatedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplNetworkReadersCreatedTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_network",
 		Name:      "readers_created_total",
@@ -169,13 +169,13 @@ var (
 	})
 )
 var (
-	metricsReplPreloadDocsNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadDocsNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_docs",
 		Name:      "num_total",
 		Help:      "num reports the total number of documents loaded during the pre-fetch stage of replication",
 	})
-	metricsReplPreloadDocsTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadDocsTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_docs",
 		Name:      "total_milliseconds",
@@ -183,13 +183,13 @@ var (
 	})
 )
 var (
-	metricsReplPreloadIndexesNumTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadIndexesNumTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_indexes",
 		Name:      "num_total",
 		Help:      "num reports the total number of index entries loaded by members before updating documents as part of the pre-fetch stage of replication",
 	})
-	metricsReplPreloadIndexesTotalMilliseconds = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsReplPreloadIndexesTotalMilliseconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_repl_preload_indexes",
 		Name:      "total_milliseconds",
@@ -197,14 +197,14 @@ var (
 	})
 )
 var (
-	metricsStorageFreelistSearchTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	metricsStorageFreelistSearchTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "metrics_storage_freelist_search_total",
 		Help:      "metrics about searching records in the database.",
 	}, []string{"type"})
 )
 var (
-	metricsTTLDeletedDocumentsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	metricsTTLDeletedDocumentsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "metrics_ttl",
 		Name:      "deleted_documents_total",

--- a/collector/network.go
+++ b/collector/network.go
@@ -5,14 +5,14 @@ import (
 )
 
 var (
-	networkBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	networkBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "network_bytes_total",
 		Help:      "The network data structure contains data regarding MongoDB's network use",
 	}, []string{"state"})
 )
 var (
-	networkMetricsNumRequestsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	networkMetricsNumRequestsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "network_metrics",
 		Name:      "num_requests_total",

--- a/collector/op_counters.go
+++ b/collector/op_counters.go
@@ -5,14 +5,14 @@ import (
 )
 
 var (
-	opCountersTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	opCountersTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_counters_total",
 		Help:      "The opcounters data structure provides an overview of database operations by type and makes it possible to analyze the load on the database in more granular manner. These numbers will grow over time and in response to database use. Analyze these values over time to track database utilization",
 	}, []string{"type"})
 )
 var (
-	opCountersReplTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	opCountersReplTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "op_counters_repl_total",
 		Help:      "The opcountersRepl data structure, similar to the opcounters data structure, provides an overview of database replication operations by type and makes it possible to analyze the load on the replica in more granular manner. These values only appear when the current host has replication enabled",

--- a/collector/oplog_status.go
+++ b/collector/oplog_status.go
@@ -3,10 +3,10 @@ package collector
 import (
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/collector/oplog_tail.go
+++ b/collector/oplog_tail.go
@@ -3,11 +3,11 @@ package collector
 import (
 	"time"
 
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rwynn/gtm"
-	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
 )
 
 var (

--- a/collector/profile_status.go
+++ b/collector/profile_status.go
@@ -1,11 +1,12 @@
 package collector
 
 import (
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
+	"time"
+
 	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
-	"time"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/collector/replset_status.go
+++ b/collector/replset_status.go
@@ -63,7 +63,7 @@ var (
 		Name:      "member_state",
 		Help:      "The value of state is an integer between 0 and 10 that represents the replica state of the member.",
 	}, []string{"set", "name"})
-	memberUptime = prometheus.NewCounterVec(prometheus.CounterOpts{
+	memberUptime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Name:      "member_uptime",

--- a/collector/replset_status.go
+++ b/collector/replset_status.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"sync"
 	"time"
 
 	"github.com/globalsign/mgo"
@@ -111,6 +112,9 @@ var (
 		Name:      "member_optime",
 		Help:      "Information regarding the last operation from the operation log that this member has applied.",
 	}, []string{"set", "name"})
+
+	// Lock for using these metrics
+	replsetStatsLock = sync.Mutex{}
 )
 
 // ReplSetStatus keeps the data returned by the GetReplSetStatus method
@@ -145,6 +149,9 @@ type Member struct {
 
 // Export exports the replSetGetStatus stati to be consumed by prometheus
 func (replStatus *ReplSetStatus) Export(ch chan<- prometheus.Metric) {
+	replsetStatsLock.Lock()
+	defer replsetStatsLock.Unlock()
+
 	myState.Reset()
 	myReplicaLag.Reset()
 	term.Reset()

--- a/collector/server_status.go
+++ b/collector/server_status.go
@@ -3,26 +3,26 @@ package collector
 import (
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	instanceUptimeSeconds = prometheus.NewCounter(prometheus.CounterOpts{
+	instanceUptimeSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "instance",
 		Name:      "uptime_seconds",
 		Help:      "The value of the uptime field corresponds to the number of seconds that the mongos or mongod process has been active.",
 	})
-	instanceUptimeEstimateSeconds = prometheus.NewCounter(prometheus.CounterOpts{
+	instanceUptimeEstimateSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "instance",
 		Name:      "uptime_estimate_seconds",
 		Help:      "uptimeEstimate provides the uptime as calculated from MongoDB's internal course-grained time keeping system.",
 	})
-	instanceLocalTime = prometheus.NewCounter(prometheus.CounterOpts{
+	instanceLocalTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "instance",
 		Name:      "local_time",

--- a/collector/storage_engine.go
+++ b/collector/storage_engine.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	storageEngine = prometheus.NewCounterVec(prometheus.CounterOpts{
+	storageEngine = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "storage_engine",
 		Help:      "The storage engine used by the MongoDB instance",

--- a/collector/tcmalloc.go
+++ b/collector/tcmalloc.go
@@ -27,13 +27,13 @@ var (
 		Help:      "Sizes for tcpmalloc caches in bytes",
 	}, []string{"cache", "type"})
 
-	tcmallocAggressiveDecommit = prometheus.NewCounter(prometheus.CounterOpts{
+	tcmallocAggressiveDecommit = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "tcmalloc_aggressive_memory_decommit",
 		Help:      "Whether aggressive_memory_decommit is on",
 	})
 
-	tcmallocFreeBytes = prometheus.NewCounter(prometheus.CounterOpts{
+	tcmallocFreeBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "tcmalloc_free_bytes",
 		Help:      "Total free bytes of tcmalloc",

--- a/collector/top_counters.go
+++ b/collector/top_counters.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	topTimeSecondsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	topTimeSecondsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "top_time_seconds_total",
 		Help:      "The top command provides operation time, in seconds, for each database collection",
 	}, []string{"type", "database", "collection"})
-	topCountTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	topCountTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "top_count_total",
 		Help:      "The top command provides operation count for each database collection",

--- a/collector/top_status.go
+++ b/collector/top_status.go
@@ -1,10 +1,10 @@
 package collector
 
 import (
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // TopStatus represents top metrics

--- a/collector/wiredtiger.go
+++ b/collector/wiredtiger.go
@@ -19,13 +19,13 @@ import (
 )
 
 var (
-	wtBlockManagerBlocksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtBlockManagerBlocksTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_blockmanager",
 		Name:      "blocks_total",
 		Help:      "The total number of blocks read by the WiredTiger BlockManager",
 	}, []string{"type"})
-	wtBlockManagerBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtBlockManagerBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_blockmanager",
 		Name:      "bytes_total",
@@ -40,7 +40,7 @@ var (
 		Name:      "pages",
 		Help:      "The current number of pages in the WiredTiger Cache",
 	}, []string{"type"})
-	wtCachePagesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtCachePagesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "pages_total",
@@ -58,13 +58,13 @@ var (
 		Name:      "max_bytes",
 		Help:      "The maximum size of data in the WiredTiger Cache in bytes",
 	})
-	wtCacheBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtCacheBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "bytes_total",
 		Help:      "The total number of bytes read into/from the WiredTiger Cache",
 	}, []string{"type"})
-	wtCacheEvictedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtCacheEvictedTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_cache",
 		Name:      "evicted_total",
@@ -79,13 +79,13 @@ var (
 )
 
 var (
-	wtTransactionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtTransactionsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "total",
 		Help:      "The total number of transactions WiredTiger has handled",
 	}, []string{"type"})
-	wtTransactionsTotalCheckpointMs = prometheus.NewCounter(prometheus.CounterOpts{
+	wtTransactionsTotalCheckpointMs = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_transactions",
 		Name:      "checkpoint_milliseconds_total",
@@ -106,25 +106,25 @@ var (
 )
 
 var (
-	wtLogRecordsScannedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	wtLogRecordsScannedTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "records_scanned_total",
 		Help:      "The total number of records scanned by log scan in the WiredTiger log",
 	})
-	wtLogRecordsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtLogRecordsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "records_total",
 		Help:      "The total number of compressed/uncompressed records written to the WiredTiger log",
 	}, []string{"type"})
-	wtLogBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtLogBytesTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "bytes_total",
 		Help:      "The total number of bytes written to the WiredTiger log",
 	}, []string{"type"})
-	wtLogOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	wtLogOperationsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "wiredtiger_log",
 		Name:      "operations_total",

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
 hash: afb4bce39984a81148a4115629075549b4e1d90d023f10ae85b6d432a3c67f7b
-updated: 2018-08-14T19:09:46.023453625-07:00
+updated: 2018-10-02T17:23:54.483643929-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
+- name: github.com/cespare/xxhash
+  version: 569f7c8abf1f58d9043ab804d364483cb1c853b6
 - name: github.com/globalsign/mgo
   version: 113d3961e7311526535a1ef7042196563d442761
   subpackages:
@@ -44,6 +46,10 @@ imports:
   - internal/util
   - nfs
   - xfs
+- name: github.com/prometheus/prometheus
+  version: 6932030aa1fdf997a79ae37da359d6af222c59c1
+  subpackages:
+  - pkg/labels
 - name: github.com/rwynn/gtm
   version: 63986e27649537009d330931e9b2a4a48c44d017
   repo: https://github.com/jacksontj/gtm.git


### PR DESCRIPTION
While using this exporter with multiple scrapers we found that sometimes metrics would be included in the metrics output more than once, resulting in error such as:

```
collected metric <REDACTED> was collected before with the same name and label values
```

This is due to the use of Reset() within the package-level metric objects. This PR adds locking around the metrics that we are using Reset() on.