### PR TITLE
Add ability to turn off specific features not present in mongos

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -47,6 +47,7 @@ type MongodbCollectorOpts struct {
 	AuthMechanism            string
 	SocketTimeout            time.Duration
 	MaxTimeMS                int64
+	Mongos                   bool
 }
 
 func (in MongodbCollectorOpts) toSessionOps() shared.MongoSessionOpts {
@@ -173,6 +174,9 @@ func (exporter *MongodbCollector) collectParameter(session *mgo.Session, ch chan
 }
 
 func (exporter *MongodbCollector) collectReplSetStatus(session *mgo.Session, ch chan<- prometheus.Metric) *ReplSetStatus {
+	if exporter.Opts.Mongos {
+		return &ReplSetStatus{}
+	}
 	replSetStatus := GetReplSetStatus(session)
 
 	if replSetStatus != nil {
@@ -184,6 +188,9 @@ func (exporter *MongodbCollector) collectReplSetStatus(session *mgo.Session, ch 
 }
 
 func (exporter *MongodbCollector) collectReplSetConf(session *mgo.Session, ch chan<- prometheus.Metric) *ReplSetConf {
+	if exporter.Opts.Mongos {
+		return &ReplSetConf{}
+	}
 	replSetConf := GetReplSetConf(session)
 
 	if replSetConf != nil {
@@ -195,6 +202,9 @@ func (exporter *MongodbCollector) collectReplSetConf(session *mgo.Session, ch ch
 }
 
 func (exporter *MongodbCollector) collectOplogStatus(session *mgo.Session, ch chan<- prometheus.Metric) *OplogStatus {
+	if exporter.Opts.Mongos {
+		return &OplogStatus{}
+	}
 	oplogStatus := GetOplogStatus(session, exporter.Opts.MaxTimeMS)
 
 	if oplogStatus != nil {

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -63,6 +63,7 @@ var (
 	mongodbSocketTimeout                = flag.Duration("mongodb.socket-timeout", 0, "timeout for socket operations to mongodb")
 	mongodbMaxTimeMS                    = flag.Duration("mongodb.maxtimems", 0, "maxTimeMs set for blocking database commands")
 	version                             = flag.Bool("version", false, "Print mongodb_exporter version")
+	mongos                              = flag.Bool("mongos", false, "Disable features only present in mongos")
 )
 
 type basicAuthHandler struct {
@@ -171,6 +172,7 @@ func registerCollector() {
 		AuthMechanism:            *mongodbAuthMechanism,
 		SocketTimeout:            *mongodbSocketTimeout,
 		MaxTimeMS:                int64(*mongodbMaxTimeMS / time.Millisecond),
+		Mongos:                   *mongos,
 	})
 	prometheus.MustRegister(mongodbCollector)
 }

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -63,7 +63,7 @@ var (
 	mongodbSocketTimeout                = flag.Duration("mongodb.socket-timeout", 0, "timeout for socket operations to mongodb")
 	mongodbMaxTimeMS                    = flag.Duration("mongodb.maxtimems", 0, "maxTimeMs set for blocking database commands")
 	version                             = flag.Bool("version", false, "Print mongodb_exporter version")
-	mongos                              = flag.Bool("mongos", false, "Disable features only present in mongos")
+	mongos                              = flag.Bool("mongos", false, "Disable features not present in mongos")
 )
 
 type basicAuthHandler struct {


### PR DESCRIPTION
Fixes errors like these:

```
E0904 00:08:54.871092       1 replset_status.go:277] Failed to get replSet status: replSetGetStatus is not supported through mongos
E0904 00:08:54.871268       1 replset_conf.go:176] Failed to get replSet config: no such cmd: replSetGetConfig
E0904 00:08:54.871485       1 oplog_status.go:127] Failed to get local.oplog_rs collection stats: Can't use 'local' database through mongos
```