### PR TITLE
fix oplog_status.go:127] Failed to get local.oplog_rs collection stat…

### DIFF
--- a/collector/oplog_status.go
+++ b/collector/oplog_status.go
@@ -87,7 +87,7 @@ func GetOplogTimestamp(session *mgo.Session, returnTail bool) (float64, error) {
 // GetOplogCollectionStats fetches oplog collection stats
 func GetOplogCollectionStats(session *mgo.Session, maxTimeMS int64) (*OplogCollectionStats, error) {
 	results := &OplogCollectionStats{}
-	err := session.DB("local").Run(bson.M{"collStats": "oplog.rs", "maxTimeMS": maxTimeMS}, &results)
+	err := session.DB("local").Run(bson.M{"collStats": "oplog.rs"}, &results)
 	return results, err
 }
 


### PR DESCRIPTION
In MongoDB 4.2 and later versions, data cannot be obtained and the monitoring error is reported：oplog_status.go:127] Failed to get local.oplog_rs collection stats: no such command: 'maxTimeMS'
fix this error, remove maxTimeMS